### PR TITLE
Quote Fargate CLI commands to avoid errors & remove newline

### DIFF
--- a/eksp-create.sh
+++ b/eksp-create.sh
@@ -125,14 +125,14 @@ printf "I will now provision the EKS cluster %s using AWS Fargate:\n\n" $CLUSTER
 # provision the EKS cluster using containerized eksctl:
 fargate task run eksctl \
           --image quay.io/mhausenblas/eksctl:$EKSCTL_IMAGE \
-          --region $(aws configure get region) \
-          --env AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) \
-          --env AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) \
-          --env AWS_DEFAULT_REGION=$(aws configure get region) \
-          --env CLUSTER_NAME=$CLUSTER_NAME \
-          --env NUM_WORKERS=$NUM_WORKERS \
-          --env KUBERNETES_VERSION=$K8S_VERSION \
-          --security-group-id $EKSPHEMERAL_SG
+          --region "$(aws configure get region)" \
+          --env AWS_ACCESS_KEY_ID="$(aws configure get aws_access_key_id)" \
+          --env AWS_SECRET_ACCESS_KEY="$(aws configure get aws_secret_access_key)" \
+          --env AWS_DEFAULT_REGION="$(aws configure get region)" \
+          --env CLUSTER_NAME="$CLUSTER_NAME" \
+          --env NUM_WORKERS="$NUM_WORKERS" \
+          --env KUBERNETES_VERSION="$K8S_VERSION" \
+          --security-group-id "$EKSPHEMERAL_SG"
 
 printf "Waiting for EKS cluster provisioning to complete. Allow some 15 min to complete, checking status every minute:\n"
 
@@ -168,4 +168,4 @@ printf "\nYour EKS cluster is now set up and configured:\n"
 kubectl config get-contexts
 
 printf "\nNote that it still can take up to 5 min until the worker nodes are available, check with the following command until you don't see the 'No resources found.' message anymore:\n"
-echo "kubectl get nodes" 
+echo "kubectl get nodes"


### PR DESCRIPTION
I was getting an error when running `eksp create`:

`
Error: accepts 1 arg(s), received 5
Usage:
  fargate task run <task name> [flags]

Flags:
  -c, --cpu string                  Amount of cpu units to allocate for each task (default "256")
  -e, --env strings                 Environment variables to set [e.g. KEY=value] (can be specified multiple times)
  -h, --help                        help for run
  -i, --image string                Docker image to run; if omitted Fargate will build an image from the Dockerfile in the current directory
  -m, --memory string               Amount of MiB to allocate for each task (default "512")
  -n, --num int                     Number of task instances to run (default 1)
      --security-group-id strings   ID of a security group to apply to the task (can be specified multiple times)
      --subnet-id strings           ID of a subnet in which to place the task (can be specified multiple times)
      --task-command strings        Command to run inside container instead of the one specified in the docker image
      --task-role string            Name or ARN of an IAM role that the tasks can assume

Global Flags:
      --cluster string   ECS cluster name (default "fargate")
      --no-color         Disable color output
      --region string    AWS region (default "us-east-1")
  -v, --verbose          Verbose output
`
Wrapping the fargate command variables in quotes, solves it.